### PR TITLE
Change Obol prometheus remote write

### DIFF
--- a/ethd
+++ b/ethd
@@ -4331,8 +4331,8 @@ config() {
 (right-click to paste)" 10 60 3>&1 1>&2 2>&3)
     __obol_prom_remote_token=$(whiptail --title "Obol prometheus" --inputbox "Put Obol Prometheus remote write token \
 (right-click to paste)" 10 60 3>&1 1>&2 2>&3)
-    cat ./prometheus/obol-prom.yml > ./prometheus/custom-prom.yml
-    sed -i'.original' "s|      credentials: OBOL_PROM_REMOTE_WRITE_TOKEN|      credentials: ${__obol_prom_remote_token}|" ./prometheus/custom-prom.yml
+    cat ./prometheus/obol-prom.yml.sample > ./prometheus/custom-prom.yml
+    sed -i'.original' "s|      credentials: <PROM_REMOTE_WRITE_TOKEN>|      credentials: ${__obol_prom_remote_token}|" ./prometheus/custom-prom.yml
     rm -f ./prometheus/custom-prom.yml.original
   fi
 

--- a/prometheus/obol-prom.yml
+++ b/prometheus/obol-prom.yml
@@ -1,8 +1,0 @@
-remote_write:
-  - url: https://vm.monitoring.gcp.obol.tech/write
-    authorization:
-      credentials: OBOL_PROM_REMOTE_WRITE_TOKEN
-    write_relabel_configs:
-      - source_labels: [job]
-        regex: "charon"
-        action: keep # Keeps charon metrics and drop metrics from other containers.

--- a/prometheus/obol-prom.yml.sample
+++ b/prometheus/obol-prom.yml.sample
@@ -1,0 +1,10 @@
+# See https://docs.obol.org/run-a-dv/start/obol-monitoring#update-the-monitoring-token-in-the-.env-file
+# Don't set anything in .env, instead append this to `custom-prom.yml` and set the <PROM_REMOTE_WRITE_TOKEN>
+remote_write:
+  - url: https://vm.monitoring.gcp.obol.tech/write
+    authorization:
+      credentials: <PROM_REMOTE_WRITE_TOKEN>
+    write_relabel_configs:
+      - source_labels: [job]
+        regex: "charon"
+        action: keep # Keeps charon metrics and drop metrics from other containers.


### PR DESCRIPTION
**What I did**

A user reports that their security tool complains about the remote write URL, in #2224 

Renaming the file to `.yml.sample` might quieten their tool, and is clearer as to intent.
