### PR TITLE
Nethermind full node parameters

### DIFF
--- a/nethermind/docker-entrypoint.sh
+++ b/nethermind/docker-entrypoint.sh
@@ -82,7 +82,7 @@ elif [[ ! "${NETWORK}" =~ ^https?:// ]]; then  # Only configure prune parameters
   if [ "${MINIMAL_NODE}" = "true" ]; then
     case "${NETWORK}" in
       mainnet )
-        echo "Methermind minimal node with pre-merge history expiry"
+        echo "Nethermind minimal node with pre-merge history expiry"
         __prune+=" --Sync.AncientBodiesBarrier=15537394 --Sync.AncientReceiptsBarrier=15537394"
         ;;
       sepolia )
@@ -92,6 +92,9 @@ elif [[ ! "${NETWORK}" =~ ^https?:// ]]; then  # Only configure prune parameters
         echo "There is no known pre-merge history for ${NETWORK}, EL_MINIMAL_NODE has no effect."
         ;;
     esac
+  else  # Full node
+    echo "Nethermind full node without history expiry"
+    __prune+=" --Sync.AncientBodiesBarrier=0 --Sync.AncientReceiptsBarrier=0"
   fi
   echo "Using pruning parameters:"
   echo "${__prune}"


### PR DESCRIPTION
**What I did**

Add parameters so a Nethermind full node still syncs all blocks and receipts, or attempts to

Nethermind now has history expiry turned on by default
