### PR TITLE
Always ask about history expiry

### DIFF
--- a/default.env
+++ b/default.env
@@ -189,7 +189,7 @@ CL_MINIMAL_NODE=true
 # or resync, depending on client
 # Erigon also has an \"aggressive\" mode that prunes even more
 # EL_ARCHIVE_NODE must be false for this to take effect
-EL_MINIMAL_NODE=false
+EL_MINIMAL_NODE=true
 # Era URLs, see https://eth-clients.github.io/history-endpoints/
 # Era1 is for pre-merge data, Era for post-merge. If these URLs are
 # not empty, an EL that supports Era import will use them when fresh syncing

--- a/ethd
+++ b/ethd
@@ -4237,8 +4237,7 @@ config() {
       __query_execution_client
     fi
 
-    if [[ "${EXECUTION_CLIENT}" =~ (erigon.yml|nimbus-el.yml) ]] \
-        && [[ "${NETWORK}" =~ (mainnet|sepolia) ]]; then
+    if [[ -n "${EXECUTION_CLIENT+x}" && "${NETWORK}" =~ (mainnet|sepolia) ]]; then
       if [[ "${__deployment}" = "rpc" ]]; then
         __query_4444 --defaultno
       else


### PR DESCRIPTION
**What I did**

During config, if the user has an execution client, and the network has pre-merge history, ask whether history expiry should be used
