### PR TITLE
Geth archive fresh sync uses path

### DIFF
--- a/geth/docker-entrypoint.sh
+++ b/geth/docker-entrypoint.sh
@@ -94,7 +94,14 @@ esac
 
 if [ "${ARCHIVE_NODE}" = "true" ]; then
   echo "Geth archive node without pruning"
-  __prune="--syncmode=full --gcmode=archive"
+  if [[ ! -d /var/lib/geth/geth/chaindata && ! -d /var/lib/goethereum/geth/chaindata ]]; then
+    touch /var/lib/geth/path-archive
+  fi
+  if [ -f /var/lib/geth/path-archive ]; then
+    __prune="--syncmode=full --state.scheme=path --history.state=0"
+  else
+    __prune="--syncmode=full --gcmode=archive"
+  fi
 elif [ "${MINIMAL_NODE}" = "true" ]; then
    echo "Geth minimal node with pre-merge history expiry"
   __prune="--history.chain postmerge"


### PR DESCRIPTION
**What I did**

Support the new path-based archive node in Geth 1.16.0. As per `--help`, `--gcmode=archive` only applies to hash scheme. in path scheme, `--history.state=0` takes this function. This is a little confusing in release notes, and gets clearer in the help text.

Snap sync in the past created a partial archive: I am assuming it's the same now. That is unlikely to have changed.

On fresh sync, set a marker to use path-based archive. If the marker is present, use the parameters for path; otherwise hash. This is done so existing archive nodes on Eth Docker do not break.