### PR TITLE
Besu 25.7.0 flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,4 @@ Eth Docker uses a "semver-ish" scheme.
 large.
 - Second through fourth digit, [semver](https://semver.org/).
 
-This is Eth Docker v2.15.3.0
+This is Eth Docker v2.16.0.0

--- a/besu/docker-entrypoint.sh
+++ b/besu/docker-entrypoint.sh
@@ -57,7 +57,7 @@ elif [ "${MINIMAL_NODE}" = "true" ]; then
   case "${NETWORK}" in
     mainnet | sepolia )
       echo "Besu minimal node with pre-merge history expiry"
-      __prune="--Xsnapsync-synchronizer-pre-merge-headers-only-enabled=true"
+      __prune="--snapsync-server-enabled"
       __timestamp_file="/var/lib/besu/prune-history-timestamp.txt"
       if [ -f "${__timestamp_file}" ]; then
         __saved_ts=$(<"${__timestamp_file}")
@@ -69,7 +69,7 @@ elif [ "${MINIMAL_NODE}" = "true" ]; then
         else
           echo "Enabling RocksDB garbage collection after history prune. You should see Besu DB space usage go down."
           echo "This may take 6-12 hours. Eth Docker will keep RocksDB garbage collection on for 48 hours."
-          __prune+=" --Xhistory-expiry-prune"
+          __prune+=" --history-expiry-prune"
         fi
       fi
       ;;
@@ -80,7 +80,7 @@ elif [ "${MINIMAL_NODE}" = "true" ]; then
   esac
 else
   echo "Besu full node without history expiry"
-  __prune=""
+  __prune="--snapsync-synchronizer-pre-merge-headers-only-enabled=false --snapsync-server-enabled"
 fi
 
 # New or old datadir


### PR DESCRIPTION
**What I did**

Configure Besu to still full sync when `EL_MINIMAL_NODE=false`, enable snap sync server, and remove `-X` from relevant flags.

Bump version as this is a breaking change for users of Besu 25.6.0 and earlier.
