### PR TITLE
Add beacon DB pruning to Prysm

### DIFF
--- a/prysm-cl-only.yml
+++ b/prysm-cl-only.yml
@@ -38,6 +38,7 @@ services:
       - MEV_NODE=${MEV_NODE}
       - CL_EXTRAS=${CL_EXTRAS:-}
       - ARCHIVE_NODE=${CL_ARCHIVE_NODE:-}
+      - MINIMAL_NODE=${CL_MINIMAL_NODE:-}
       - NETWORK=${NETWORK}
     ports:
       - ${HOST_IP:-}:${PRYSM_PORT}:${PRYSM_PORT}/tcp

--- a/prysm.yml
+++ b/prysm.yml
@@ -38,6 +38,7 @@ services:
       - MEV_NODE=${MEV_NODE}
       - CL_EXTRAS=${CL_EXTRAS:-}
       - ARCHIVE_NODE=${CL_ARCHIVE_NODE:-}
+      - MINIMAL_NODE=${CL_MINIMAL_NODE:-}
       - NETWORK=${NETWORK}
     ports:
       - ${HOST_IP:-}:${PRYSM_PORT}:${PRYSM_PORT}/tcp

--- a/prysm/docker-entrypoint.sh
+++ b/prysm/docker-entrypoint.sh
@@ -64,7 +64,11 @@ fi
 if [ "${ARCHIVE_NODE}" = "true" ]; then
   echo "Prysm archive node without pruning"
   __prune="--slots-per-archive-point=32 --blob-retention-epochs=4294967295"
+elif [ "${MINIMAL_NODE}" = "true" ]; then
+  echo "Prysm node with beacon DB pruning"
+  __prune="--beacon-db-pruning"
 else
+  echo "Prysm node without beacon DB pruning"
   __prune=""
 fi
 


### PR DESCRIPTION
**What I did**

Added `--beacon-db-pruning` option for Prysm, which keeps the DB size constant. They introduced this in `v5.3.0` but buried it in release notes - they don't even mention the name of the flag and it's halfway through the changes section.
