### PR TITLE
[LIDO] feat: add Obol remote Loki url configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ ssv-config.yaml.bak
 blox-ssv-config.yaml
 blox-ssv-config.yaml.bak
 promtail/custom-lokiurl.yml
+promtail-obol/config.yml
 ssv-config/password.pass
 ssv-config/password
 ssv-config/encrypted_private_key.json

--- a/default.env
+++ b/default.env
@@ -97,6 +97,10 @@ OBOL_P2P_RELAYS=
 OBOL_P2P_EXTERNAL_HOSTNAME=
 # Allows operators to set human readable nicknames in monitoring. Works from v1.3.0 only. Empty by default
 OBOL_CHARON_NICKNAME=
+# Obol remote Logging
+OBOL_CHARON_REMOTE_LOKI_ADDRESSES=
+OBOL_CLUSTER_NAME=
+OBOL_CLUSTER_PEER=
 
 # External Docker network if using ext-network.yml
 DOCKER_EXT_NETWORK=rocketpool_net
@@ -427,4 +431,4 @@ NODE_EXPORTER_IGNORE_MOUNT_REGEX='^/(dev|proc|sys|run|var/snap/.+|var/lib/docker
 DOCKER_ROOT=/var/lib/docker
 
 # Used by ethd update - please do not adjust
-ENV_VERSION=39
+ENV_VERSION=40

--- a/ethd
+++ b/ethd
@@ -4449,7 +4449,11 @@ config() {
       OBOL_CLUSTER_PEER=$(whiptail --title "Obol cluster peer" --inputbox "Put your Obol cluster peer \
 (right-click to paste)" 10 60 "eth-docker" 3>&1 1>&2 2>&3)
     else
+# This gets used, but shellcheck doesn't recognize that
+# shellcheck disable=SC2034
       OBOL_CLUSTER_NAME=""
+# This gets used, but shellcheck doesn't recognize that
+# shellcheck disable=SC2034
       OBOL_CLUSTER_PEER=""
       echo "Obol Loki remote URL is empty, skipping"
     fi

--- a/ethd
+++ b/ethd
@@ -4436,11 +4436,23 @@ config() {
 # shellcheck disable=SC2034
     VE_OPERATOR_ID=$(whiptail --title "Lido Operator ID" --inputbox "Put your Operator ID from Lido Operators dashboard \
 (right-click to paste)" 10 60 3>&1 1>&2 2>&3)
-    __obol_prom_remote_token=$(whiptail --title "Obol prometheus" --inputbox "Put Obol Prometheus remote write token \
+    __obol_prom_remote_token=$(whiptail --title "Obol Prometheus" --inputbox "Put Obol Prometheus remote write token \
 (right-click to paste)" 10 60 3>&1 1>&2 2>&3)
     cat ./prometheus/obol-prom.yml.sample > ./prometheus/custom-prom.yml
     sed -i'.original' "s|      credentials: <PROM_REMOTE_WRITE_TOKEN>|      credentials: ${__obol_prom_remote_token}|" ./prometheus/custom-prom.yml
     rm -f ./prometheus/custom-prom.yml.original
+    OBOL_CHARON_REMOTE_LOKI_ADDRESSES=$(whiptail --title "Obol Loki" --inputbox "Put Obol Loki remote URL \
+(right-click to paste)" 10 60 3>&1 1>&2 2>&3)
+    if [ -n "${OBOL_CHARON_REMOTE_LOKI_ADDRESSES}" ]; then
+      OBOL_CLUSTER_NAME=$(whiptail --title "Obol cluster name" --inputbox "Put your Obol cluster name \
+(right-click to paste)" 10 60 "Eth Docker" 3>&1 1>&2 2>&3)
+      OBOL_CLUSTER_PEER=$(whiptail --title "Obol cluster peer" --inputbox "Put your Obol cluster peer \
+(right-click to paste)" 10 60 "eth-docker" 3>&1 1>&2 2>&3)
+    else
+      OBOL_CLUSTER_NAME=""
+      OBOL_CLUSTER_PEER=""
+      echo "Obol Loki remote URL is empty, skipping"
+    fi
   fi
 
   if [ "${CONSENSUS_CLIENT}" = "caplin" ]; then
@@ -4465,6 +4477,9 @@ config() {
   fi
   if [ "${__deployment}" = "lido_obol" ]; then
     COMPOSE_FILE="${COMPOSE_FILE}:lido-obol.yml"
+    if [ -n "${OBOL_CHARON_REMOTE_LOKI_ADDRESSES}" ]; then
+      COMPOSE_FILE="${COMPOSE_FILE}:lido-obol-promtail.yml"
+    fi
   fi
   if { [ "${__deployment}" = "node" ] || [ "${__deployment}" = "rocket" ]; } \
   && [ "${NETWORK}" = "hoodi" ]; then
@@ -4533,6 +4548,12 @@ config() {
     __var=VE_ORACLE_ADDRESSES_ALLOWLIST
     __update_value_in_env "${__var}" "${!__var-}" "${__env_file}"
     __var=VE_STAKING_MODULE_ID
+    __update_value_in_env "${__var}" "${!__var-}" "${__env_file}"
+    __var=OBOL_CHARON_REMOTE_LOKI_ADDRESSES
+    __update_value_in_env "${__var}" "${!__var-}" "${__env_file}"
+    __var=OBOL_CLUSTER_NAME
+    __update_value_in_env "${__var}" "${!__var-}" "${__env_file}"
+    __var=OBOL_CLUSTER_PEER
     __update_value_in_env "${__var}" "${!__var-}" "${__env_file}"
 # We are using the variable
 # shellcheck disable=SC2034

--- a/lido-obol-promtail.yml
+++ b/lido-obol-promtail.yml
@@ -1,0 +1,26 @@
+services:
+
+  promtail-obol:
+    image: grafana/promtail:latest
+    user: root
+    volumes:
+      - ./promtail-obol:/etc/promtail
+      - promtail-obol-data:/tmp
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ${DOCKER_ROOT:-/var/lib/docker}/containers:/var/lib/docker/containers:ro,rslave
+    entrypoint: ./etc/promtail/entrypoint.sh
+    command: ["/usr/bin/promtail"]
+    environment:
+      CHARON_LOKI_ADDRESSES: ${OBOL_CHARON_REMOTE_LOKI_ADDRESSES}
+      CLUSTER_NAME: ${OBOL_CLUSTER_NAME}
+      CLUSTER_PEER: ${OBOL_CLUSTER_PEER}
+    restart: "unless-stopped"
+    labels:
+      - metrics.scrape=true
+      - metrics.path=/metrics
+      - metrics.port=9080
+      - metrics.instance=obol-promtail
+      - metrics.network=${NETWORK}
+
+volumes:
+    promtail-obol-data:

--- a/lido-obol.yml
+++ b/lido-obol.yml
@@ -24,7 +24,7 @@ services:
       - CHARON_MONITORING_ADDRESS=0.0.0.0:3620
       - CHARON_BUILDER_API=${BUILDER_API_ENABLED:-true}
       - CHARON_FEATURE_SET_ENABLE=eager_double_linear,consensus_participate
-      - CHARON_LOKI_ADDRESSES=${CHARON_LOKI_ADDRESSES:-http://loki:3100/loki/api/v1/push}
+      - CHARON_LOKI_ADDRESSES=http://loki:3100/loki/api/v1/push${OBOL_CHARON_REMOTE_LOKI_ADDRESSES:+,${OBOL_CHARON_REMOTE_LOKI_ADDRESSES}}
       - CHARON_LOKI_SERVICE=charon
       - CHARON_NICKNAME=${OBOL_CHARON_NICKNAME:-}
     ports:

--- a/promtail-obol/config.yml.example
+++ b/promtail-obol/config.yml.example
@@ -1,0 +1,59 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+scrape_configs:
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+    relabel_configs:
+      - source_labels: ['__meta_docker_container_name']
+        regex: '/(.*)'
+        replacement: '$1'
+        target_label: 'container'
+
+      # Simple fallback strategy - determine job only by container name
+      - source_labels: ['container']
+        regex: '.*execution.*'
+        replacement: 'lido-execution'
+        target_label: 'job'
+
+      - source_labels: ['container']
+        regex: '.*consensus.*'
+        replacement: 'lido-consensus'
+        target_label: 'job'
+
+      - source_labels: ['container']
+        regex: '.*validator.*'
+        replacement: 'lido-validator'
+        target_label: 'job'
+
+      - source_labels: ['container']
+        regex: '.*mev-boost.*'
+        replacement: 'lido-mev-boost'
+        target_label: 'job'
+
+      - source_labels: ['container']
+        regex: '.*charon.*'
+        replacement: 'lido-charon'
+        target_label: 'job'
+
+      # Drop unknown containers that we don't want to monitor
+      - source_labels: ['job']
+        regex: '^$'
+        action: drop
+
+      - target_label: 'cluster_name'
+        replacement: "$CLUSTER_NAME"
+
+      - target_label: 'cluster_peer'
+        replacement: "$CLUSTER_PEER"
+
+    pipeline_stages:
+      - docker: {}
+
+clients:
+  - url: $CHARON_LOKI_ADDRESSES

--- a/promtail-obol/entrypoint.sh
+++ b/promtail-obol/entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+if [ -z "$CHARON_LOKI_ADDRESSES" ]; then
+  echo "Error: \$CHARON_LOKI_ADDRESSES variable is empty" >&2
+  exit 1
+fi
+
+if [ -z "$CLUSTER_NAME" ]; then
+  echo "Error: \$CLUSTER_NAME variable is empty" >&2
+  exit 1
+fi
+
+if [ -z "$CLUSTER_PEER" ]; then
+  echo "Error: \$CLUSTER_PEER variable is empty" >&2
+  exit 1
+fi
+
+# Process the template file once
+sed -e "s|\$CHARON_LOKI_ADDRESSES|${CHARON_LOKI_ADDRESSES}|g" \
+    -e "s|\$CLUSTER_NAME|${CLUSTER_NAME}|g" \
+    -e "s|\$CLUSTER_PEER|${CLUSTER_PEER}|g" \
+    /etc/promtail/config.yml.example > /etc/promtail/config.yml
+
+exec "$@" --config.file=/etc/promtail/config.yml


### PR DESCRIPTION
**What I did**

Added a separate promtail instance to Obol configuration to send logs from main containers (CL, EL, Validator, etc.) with specific labels to a remote Loki URL.

The implementation was inspired by https://github.com/ObolNetwork/lido-charon-distributed-validator-node

I didn't find a way how to get client names to have it in labels :(

