### PR TITLE
Improve defaults for NODE variables

### DIFF
--- a/default.env
+++ b/default.env
@@ -231,15 +231,15 @@ PORTAL_ALIAS=${NETWORK}-portal
 # MEV-boost address. This would only be changed for Vouch setups
 MEV_NODE=http://${MEV_ALIAS}:18550
 # Web3signer address - match service name or alias, or it can be remote
-W3S_NODE=http://web3signer:9000
+W3S_NODE=http://${NETWORK}-web3signer:9000
 # Consensus client addresses for Charon in Obol setup
-OBOL_CHARON_CL_ENDPOINTS=http://consensus:5052
+OBOL_CHARON_CL_ENDPOINTS=http://${NETWORK}-consensus:${CL_REST_PORT}
 # Consensus client address for Lido DV Exit and Lido Validator Ejector services in Obol setup
-OBOL_CL_NODE=http://consensus:5052
+OBOL_CL_NODE=http://${NETWORK}-consensus:${CL_REST_PORT}
 # Execution client address (RPC) for Lido Validator Ejector in Obol setup, and SSV pulse, and SSV Anchor
-EL_RPC_NODE=http://execution:${EL_RPC_PORT}
+EL_RPC_NODE=http://${NETWORK}-execution:${EL_RPC_PORT}
 # Execution client address (WS) for SSV Anchor
-EL_WS_NODE=ws://execution:${EL_WS_PORT}
+EL_WS_NODE=ws://${NETWORK}-execution:${EL_WS_PORT}
 
 # You can set specific version targets and choose binary or compiled from source builds below,
 # via "Dockerfile.binary" or "Dockerfile.source"


### PR DESCRIPTION
**What I did**

A user has two eth docker stacks, one at defaults and one with specific aliases, on the same bridge network

This fails badly because `W3S_NODE=http://web3signer:9000` on the default stack, which round-robins

This change makes the defaults more unique. The user still has to change the aliases on the second stack, but at least the default stack no longer uses the service name, but uses the alias.
