### PR TITLE
Support pre-confs

### DIFF
--- a/commit-boost-pbs.yml
+++ b/commit-boost-pbs.yml
@@ -11,9 +11,8 @@ services:
     image: ${CB_PBS_DOCKER_REPO:-ghcr.io/commit-boost/pbs}:${CB_PBS_DOCKER_TAG:-latest}
     environment:
       CB_CONFIG: /cb-config.toml
-      CB_METRICS_PORT: 10000
     volumes:
-    - ./commit-boost/cb-config.toml:/cb-config.toml:ro
+      - ./commit-boost/cb-config.toml:/cb-config.toml:ro
     networks:
       default:
         aliases:

--- a/commit-boost-signer.yml
+++ b/commit-boost-signer.yml
@@ -1,0 +1,57 @@
+x-logging: &logging
+  logging:
+    driver: json-file
+    options:
+      max-size: 100m
+      max-file: "3"
+      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+
+services:
+  cb-signer-init:
+    build:
+      context: ./commit-boost
+      dockerfile: Dockerfile.signer-init
+    image: init:cb-signer
+    restart: no
+    environment:
+      COMPOSE_FILE: ${COMPOSE_FILE}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+      WEB3SIGNER: ${WEB3SIGNER:-false}
+      W3S_NODE: ${W3S_NODE}
+    volumes:
+      - ./commit-boost/cb-config.toml:/cb-config.toml
+
+  cb-signer:
+    image: ${CB_SIGNER_DOCKER_REPO:-ghcr.io/commit-boost/pbs}:${CB_SIGNER_DOCKER_TAG:-latest}
+    environment:
+      CB_CONFIG: /cb-config.toml
+    volumes:
+      - ./commit-boost/cb-config.toml:/cb-config.toml:ro
+      - lhvalidator-data:/var/lib/lighthouse
+      - lsvalidator-data:/var/lib/lodestar
+      - prysmvalidator-data:/var/lib/prysm
+      - teku-data:/var/lib/teku
+      - teku-vc-data:/var/lib/teku-vc
+      - nimbus-vc-data:/var/lib/nimbus
+    depends_on:
+      cb-signer-init:
+        condition: service_completed_successfully
+
+    networks:
+      default:
+        aliases:
+          - ${CB_SIGNER_ALIAS:-cb-signer-${NETWORK}}  # This allows multiple Eth Docker stacks all connected to the same bridge network
+    labels:
+      - metrics.scrape=true
+      - metrics.path=/metrics
+      - metrics.port=10000
+      - metrics.instance=cb-signer
+      - metrics.network=${NETWORK}
+
+volumes:
+  lhvalidator-data:
+  lsvalidator-data:
+  prysmvalidator-data:
+  teku-data:
+  teku-vc-data:
+  nimbus-vc-data:

--- a/commit-boost/Dockerfile.signer-init
+++ b/commit-boost/Dockerfile.signer-init
@@ -1,0 +1,9 @@
+FROM python:3.13-alpine
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir tomlkit
+
+COPY ./signer-init.py .
+
+ENTRYPOINT ["python", "signer-init.py"]

--- a/commit-boost/cb-config-signer.toml.sample
+++ b/commit-boost/cb-config-signer.toml.sample
@@ -1,0 +1,53 @@
+# See https://github.com/Commit-Boost/commit-boost-client/blob/main/config.example.toml
+chain = "Hoodi"
+
+[pbs]
+port = 18550
+host = "0.0.0.0"
+with_signer = true
+
+[[relays]]
+id = "aestus"
+url = "https://0x98f0ef62f00780cf8eb06701a7d22725b9437d4768bb19b363e882ae87129945ec206ec2dc16933f31d983f8225772b6@hoodi.aestus.live"
+[[relays]]
+id = "titan"
+url = "https://0xaa58208899c6105603b74396734a6263cc7d947f444f396a90f7b7d3e65d102aec7e5e5291b27e08d02c50a050825c2f@hoodi.titanrelay.xyz"
+[[relays]]
+id = "flashbots"
+url = "https://0xafa4c6985aa049fb79dd37010438cfebeb0f2bd42b115b89dd678dab0670c1de38da0c4e9138c9290a398ecd9a0b3110@boost-relay-hoodi.flashbots.net"
+[[relays]]
+id = "ultrasound"
+url = "https://0xb1559beef7b5ba3127485bbbb090362d9f497ba64e177ee2c8e7db74746306efad687f2cf8574e38d70067d40ef136dc@relay-hoodi.ultrasound.money"
+
+# For Remote signer:
+# [signer.remote]
+# URL of the Web3Signer instance
+# url = "https://remote.signer.url"
+
+# [signer.local.loader]
+# ValidatorsDir: format of the keystore (lighthouse, prysm, teku, lodestar, or nimbus)
+# format = "lighthouse"
+# ValidatorsDir: full path to the keys directory
+# For lighthouse, it's the path to the directory where the `<pubkey>` directories are located, under each of which is a `voting-keystore.json` file.
+# For prysm, it's the path to the `all-accounts.keystore.json` file.
+# For teku, it's the path to the directory where all `<pubkey>.json` files are located.
+# For lodestar, it's the path to the directory where all `<pubkey>.json` files are located.
+# For nimbus, it's the path to the directory where the `<pubkey>` directories are located, under each of which is a `keystore.json` file.
+# keys_path = ""
+# ValidatorsDir: full path to the secrets file/directory
+# For lighthouse, it's the path to the directory where the `<pubkey>` files are located.
+# For prysm, it's the path to the file containing the wallet decryption password.
+# For teku, it's the path to the directory where all `<pubkey>.txt` files are located.
+# For lodestar, it's the path to the file containing the decryption password.
+# For nimbus, it's the path to the directory where the `<pubkey>` files are located.
+# secrets_path = ""
+
+[metrics]
+port = 10000
+host = "0.0.0.0"
+
+[logs.stdout]
+level = "info"
+
+[logs.file]
+enabled = false

--- a/commit-boost/cb-config.toml.sample
+++ b/commit-boost/cb-config.toml.sample
@@ -1,7 +1,9 @@
+# See https://github.com/Commit-Boost/commit-boost-client/blob/main/config.example.toml
 chain = "Hoodi"
 
 [pbs]
 port = 18550
+host = "0.0.0.0"
 
 [[relays]]
 id = "aestus"
@@ -15,3 +17,13 @@ url = "https://0xafa4c6985aa049fb79dd37010438cfebeb0f2bd42b115b89dd678dab0670c1d
 [[relays]]
 id = "ultrasound"
 url = "https://0xb1559beef7b5ba3127485bbbb090362d9f497ba64e177ee2c8e7db74746306efad687f2cf8574e38d70067d40ef136dc@relay-hoodi.ultrasound.money"
+
+[metrics]
+port = 10000
+host = "0.0.0.0"
+
+[logs.stdout]
+level = "info"
+
+[logs.file]
+enabled = false

--- a/commit-boost/signer-init.py
+++ b/commit-boost/signer-init.py
@@ -1,0 +1,56 @@
+import os
+import logging
+import sys
+import tomlkit
+from pathlib import Path
+from collections.abc import Mapping
+from typing import Any
+from tomlkit.toml_document import TOMLDocument
+
+logger = logging.getLogger("signer-init")
+if not logger.handlers:
+    _handler = logging.StreamHandler(sys.stdout)
+    _handler.setFormatter(logging.Formatter("%(asctime)s [%(levelname)s] %(message)s"))
+    logger.addHandler(_handler)
+    _level = os.getenv("LOG_LEVEL", "INFO").upper()
+    logger.setLevel(getattr(logging, _level, logging.INFO))
+    logger.propagate = False  # Prevent propagation to root logger
+
+def getenv_bool(name: str, default: bool = False) -> bool:
+    val = os.getenv(name)
+    if val is None:
+        return default
+    return val.strip().lower() in {"true"}
+
+# Load environment variables
+COMPOSE_FILE = os.environ["COMPOSE_FILE"]
+WEB3SIGNER = getenv_bool("WEB3SIGNER", default=False)
+W3S_NODE = os.getenv("W3S_NODE", "")
+LOG_LEVEL = os.getenv("LOG_LEVEL", "info").lower()
+
+def get_in(mapping: Mapping[str, Any] ,path: str, default: Any=None) -> Any:
+    """Safe lookup like 'signer.remote.url'."""
+    cur = mapping
+    for key in path.split("."):
+        if isinstance(cur, Mapping) and key in cur:
+            cur = cur[key]
+        else:
+            return default
+    return cur
+
+def update_signer(doc: TOMLDocument) -> None:
+
+def main():
+    path = Path("/cb-config.toml")
+    doc = tomlkit.parse(path.read_text(encoding="utf-8"))
+
+    doc["logs"]["stdout"]["level"] = LOG_LEVEL
+
+    update_signer(doc)
+
+    path.write_text(tomlkit.dumps(doc), encoding="utf-8")
+
+    sys.exit(0)
+
+if __name__ == "__main__":
+    main()

--- a/default.env
+++ b/default.env
@@ -268,6 +268,9 @@ CONTRIBUTOOR_DOCKER_TAG=latest
 # Commit-Boost
 CB_PBS_DOCKER_TAG=latest
 CB_PBS_DOCKER_REPO=ghcr.io/commit-boost/pbs
+CB_SIGNER_DOCKER_TAG=latest
+CB_SIGNER_DOCKER_REPO=ghcr.io/commit-boost/signer
+
 # MEV-Boost
 # SRC build target can be a tag, a branch, or a pr as "pr-ID"
 MEV_SRC_BUILD_TARGET=stable
@@ -413,4 +416,4 @@ NODE_EXPORTER_IGNORE_MOUNT_REGEX='^/(dev|proc|sys|run|var/snap/.+|var/lib/docker
 DOCKER_ROOT=/var/lib/docker
 
 # Used by ethd update - please do not adjust
-ENV_VERSION=40
+ENV_VERSION=41


### PR DESCRIPTION
**What I did**

~~Add support for cb-signer. For better UX, a Python init script does some sanity checking of the config and sets the variables correctly for different clients.~~

After reflection, a better target is support for certain pre-confirmations, and use web3signer as the signing module. This could be pre-confirmations for based rollups, or projects like ethgas.

As of July 2026 support for based rollups remains unclear to me. It is also the area I see most deserving of support.

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

<img width="1680" height="940" alt="image" src="https://github.com/user-attachments/assets/b7f96361-037d-411a-af96-9eeb2aa0e9d6" />
