### PR TITLE
Fix source builds broken by lint adjustment

### DIFF
--- a/besu/Dockerfile.source
+++ b/besu/Dockerfile.source
@@ -1,4 +1,4 @@
-# hadolint global ignore=DL3007,DL3008,DL3059
+# hadolint global ignore=DL3007,DL3008,DL3059,DL4006
 # Build Besu in a stock Ubuntu container
 FROM eclipse-temurin:21-jdk-noble AS builder
 
@@ -12,8 +12,7 @@ ARG SRC_REPO
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates git libjemalloc-dev
 
 WORKDIR /usr/src
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN "git clone --recurse-submodules -j8 ${SRC_REPO} besu && cd besu \
+RUN bash -o pipefail -c "git clone --recurse-submodules -j8 ${SRC_REPO} besu && cd besu \
   && git config advice.detachedHead false && git fetch --all --tags \
   && if [[ ${BUILD_TARGET} =~ pr-.+ ]]; then git fetch origin pull/$(echo ${BUILD_TARGET} | cut -d '-' -f 2)/head:besu-pr; git checkout besu-pr; else git checkout ${BUILD_TARGET}; fi \
   && git submodule update --init --recursive &&./gradlew installDist"

--- a/erigon/Dockerfile.source
+++ b/erigon/Dockerfile.source
@@ -1,4 +1,4 @@
-# hadolint global ignore=DL3007,DL3008,DL3059
+# hadolint global ignore=DL3007,DL3008,DL3059,DL4006
 # Build Erigon in a stock Go build container
 FROM golang:1.25-trixie AS builder
 
@@ -10,8 +10,7 @@ ARG BUILD_TARGET
 ARG SRC_REPO
 
 WORKDIR /src
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN "git clone ${SRC_REPO} erigon && cd erigon && git config advice.detachedHead false && git fetch --all --tags && \
+RUN bash -o pipefail -c "git clone ${SRC_REPO} erigon && cd erigon && git config advice.detachedHead false && git fetch --all --tags && \
 if [[ ${BUILD_TARGET} =~ pr-.+ ]]; then git fetch origin pull/$(echo ${BUILD_TARGET} | cut -d '-' -f 2)/head:erigon-pr; git checkout erigon-pr; else git checkout ${BUILD_TARGET}; fi && make BUILD_TAGS=nosqlite,noboltdb,nosilkworm erigon"
 
 # Pull all binaries into a second stage deploy container

--- a/ethstaker-deposit-cli/Dockerfile.source
+++ b/ethstaker-deposit-cli/Dockerfile.source
@@ -1,4 +1,4 @@
-# hadolint global ignore=DL3007,DL3008,DL3059
+# hadolint global ignore=DL3007,DL3008,DL3059,DL4006
 FROM python:3.13-trixie AS builder
 
 ARG BUILD_TARGET
@@ -12,8 +12,7 @@ RUN mkdir -p /src
 RUN apt-get update && apt-get install -y --no-install-recommends bash git
 
 WORKDIR /src
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN "git clone ${SRC_REPO} ethstaker-deposit-cli && cd ethstaker-deposit-cli && git config advice.detachedHead false && git fetch --all --tags \
+RUN bash -o pipefail -c "git clone ${SRC_REPO} ethstaker-deposit-cli && cd ethstaker-deposit-cli && git config advice.detachedHead false && git fetch --all --tags \
   && if [[ ${BUILD_TARGET} =~ pr-.+ ]]; then git fetch origin pull/$(echo ${BUILD_TARGET} | cut -d '-' -f 2)/head:deposit-pr; git checkout deposit-pr; else git checkout ${BUILD_TARGET}; fi"
 
 FROM python:3.13-trixie

--- a/flashbots/Dockerfile.source
+++ b/flashbots/Dockerfile.source
@@ -1,4 +1,4 @@
-# hadolint global ignore=DL3007,DL3008,DL3018,DL3059
+# hadolint global ignore=DL3007,DL3008,DL3018,DL3059,DL4006
 # Build in a stock Go build container
 FROM golang:1.24-alpine AS builder
 
@@ -12,8 +12,7 @@ ARG SRC_REPO
 RUN apk update && apk add --no-cache make gcc musl-dev linux-headers git bash
 
 WORKDIR /src
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN "git clone ${SRC_REPO} mev-boost && cd mev-boost && git config advice.detachedHead false && git fetch --all --tags && \
+RUN bash -o pipefail -c "git clone ${SRC_REPO} mev-boost && cd mev-boost && git config advice.detachedHead false && git fetch --all --tags && \
 if [[ ${BUILD_TARGET} =~ pr-.+ ]]; then git fetch origin pull/$(echo ${BUILD_TARGET} | cut -d '-' -f 2)/head:mev-pr; git checkout mev-pr; else git checkout ${BUILD_TARGET}; fi && \
 make build"
 

--- a/geth/Dockerfile.source
+++ b/geth/Dockerfile.source
@@ -1,4 +1,4 @@
-# hadolint global ignore=DL3007,DL3008,DL3018,DL3059
+# hadolint global ignore=DL3007,DL3008,DL3018,DL3059,DL4006
 # Build Geth in a stock Go build container
 FROM golang:1.25-alpine AS builder
 
@@ -12,8 +12,7 @@ ARG SRC_REPO
 RUN apk update && apk add --no-cache make gcc musl-dev linux-headers git bash
 
 WORKDIR /src
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN "git clone ${SRC_REPO} go-ethereum && cd go-ethereum && git config advice.detachedHead false && git fetch --all --tags && \
+RUN bash -o pipefail -c "git clone ${SRC_REPO} go-ethereum && cd go-ethereum && git config advice.detachedHead false && git fetch --all --tags && \
 if [[ ${BUILD_TARGET} =~ pr-.+ ]]; then git fetch origin pull/$(echo ${BUILD_TARGET} | cut -d '-' -f 2)/head:geth-pr; git checkout geth-pr; else git checkout ${BUILD_TARGET}; fi && \
 go run build/ci.go install -static"
 

--- a/grandine/Dockerfile.source
+++ b/grandine/Dockerfile.source
@@ -1,4 +1,4 @@
-# hadolint global ignore=DL3007,DL3008,DL3059
+# hadolint global ignore=DL3007,DL3008,DL3059,DL4006
 # Build Grandine in a stock Rust build container
 FROM rust:trixie AS builder
 
@@ -12,8 +12,7 @@ ARG SRC_REPO
 RUN apt-get update && apt-get -y dist-upgrade && apt-get install -y --no-install-recommends cmake libclang-dev protobuf-compiler libz-dev libssl-dev unzip
 
 WORKDIR /usr/src
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN "git clone ${SRC_REPO} grandine && cd grandine && git config advice.detachedHead false \
+RUN bash -o pipefail -c "git clone ${SRC_REPO} grandine && cd grandine && git config advice.detachedHead false \
 && git fetch --all --tags \
 && if [[ ${BUILD_TARGET} =~ pr-.+ ]]; then git fetch origin pull/$(echo ${BUILD_TARGET} | cut -d '-' -f 2)/head:gd-pr; git checkout gd-pr; else git checkout ${BUILD_TARGET}; fi \
 && git submodule update --init dedicated_executor eth2_libp2p \

--- a/lighthouse/Dockerfile.source
+++ b/lighthouse/Dockerfile.source
@@ -1,4 +1,4 @@
-# hadolint global ignore=DL3007,DL3008,DL3059
+# hadolint global ignore=DL3007,DL3008,DL3059,DL4006
 # Build Lighthouse in a stock Rust build container
 FROM rust:trixie AS builder
 
@@ -13,8 +13,7 @@ ENV FEATURES modern,gnosis,slasher-lmdb,jemalloc
 RUN apt-get update && apt-get -y dist-upgrade && apt-get install -y --no-install-recommends cmake libclang-dev protobuf-compiler
 
 WORKDIR /usr/src
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN "git clone ${SRC_REPO} lighthouse && cd lighthouse && git config advice.detachedHead false && git fetch --all --tags && if [[ ${BUILD_TARGET} =~ pr-.+ ]]; then git fetch origin pull/$(echo ${BUILD_TARGET} | cut -d '-' -f 2)/head:lh-pr; git checkout lh-pr; else git checkout ${BUILD_TARGET}; fi && CROSS_PROFILE=maxperf make"
+RUN bash -o pipefail -c "git clone ${SRC_REPO} lighthouse && cd lighthouse && git config advice.detachedHead false && git fetch --all --tags && if [[ ${BUILD_TARGET} =~ pr-.+ ]]; then git fetch origin pull/$(echo ${BUILD_TARGET} | cut -d '-' -f 2)/head:lh-pr; git checkout lh-pr; else git checkout ${BUILD_TARGET}; fi && CROSS_PROFILE=maxperf make"
 
 # Pull all binaries into a second stage deploy debian container
 FROM debian:trixie-slim

--- a/lodestar/Dockerfile.source
+++ b/lodestar/Dockerfile.source
@@ -1,4 +1,4 @@
-# hadolint global ignore=DL3007,DL3008,DL3059
+# hadolint global ignore=DL3007,DL3008,DL3059,DL4006
 FROM node:22-slim AS builder
 
 # Here only to avoid build-time errors
@@ -11,8 +11,7 @@ ARG SRC_REPO
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates git g++ make python3 python3-setuptools bash && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/app
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN "cd .. && rm -rf app && git clone ${SRC_REPO} app && cd app && git config advice.detachedHead false \
+RUN bash -o pipefail -c "cd .. && rm -rf app && git clone ${SRC_REPO} app && cd app && git config advice.detachedHead false \
   && git fetch --all --tags \
   && if [[ ${BUILD_TARGET} =~ pr-.+ ]]; then git fetch origin pull/$(echo ${BUILD_TARGET} | cut -d '-' -f 2)/head:ls-pr; git checkout ls-pr; else git checkout ${BUILD_TARGET}; fi \
   && yarn install --non-interactive --frozen-lockfile && yarn build"

--- a/nethermind/Dockerfile.source
+++ b/nethermind/Dockerfile.source
@@ -1,4 +1,4 @@
-# hadolint global ignore=DL3007,DL3008,DL3059
+# hadolint global ignore=DL3007,DL3008,DL3059,DL4006
 # Partially from Nethermind github
 FROM mcr.microsoft.com/dotnet/sdk:9.0 AS builder
 # Unused, this is here to avoid build time complaints
@@ -11,8 +11,7 @@ ARG SRC_REPO
 WORKDIR /
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends git
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN "\
+RUN bash -o pipefail -c "\
     git clone ${SRC_REPO} nethermind && \
     cd nethermind && \
     git config advice.detachedHead false && \

--- a/nimbus-el/Dockerfile.source
+++ b/nimbus-el/Dockerfile.source
@@ -1,4 +1,4 @@
-# hadolint global ignore=DL3007,DL3008,DL3059
+# hadolint global ignore=DL3007,DL3008,DL3059,DL4006
 # Build Nimbus in a stock debian container
 FROM debian:trixie-slim AS builder
 
@@ -13,8 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends build-essential
 
 WORKDIR /usr/src
 
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN "git clone ${SRC_REPO} nimbus-eth1 && cd nimbus-eth1 && git config advice.detachedHead false && git fetch --all --tags && if [[ ${BUILD_TARGET} =~ pr-.+ ]]; then git fetch origin pull/$(echo ${BUILD_TARGET} | cut -d '-' -f 2)/head:nim-pr; git checkout nim-pr; else git checkout ${BUILD_TARGET}; fi && make -j$(nproc) update && make -j$(nproc) nimbus_execution_client"
+RUN bash -o pipefail -c "git clone ${SRC_REPO} nimbus-eth1 && cd nimbus-eth1 && git config advice.detachedHead false && git fetch --all --tags && if [[ ${BUILD_TARGET} =~ pr-.+ ]]; then git fetch origin pull/$(echo ${BUILD_TARGET} | cut -d '-' -f 2)/head:nim-pr; git checkout nim-pr; else git checkout ${BUILD_TARGET}; fi && make -j$(nproc) update && make -j$(nproc) nimbus_execution_client"
 
 # Pull all binaries into a second stage deploy debian container
 FROM debian:trixie-slim

--- a/nimbus/Dockerfile.source
+++ b/nimbus/Dockerfile.source
@@ -1,4 +1,4 @@
-# hadolint global ignore=DL3007,DL3008,DL3059
+# hadolint global ignore=DL3007,DL3008,DL3059,DL4006
 # Build Nimbus in a stock Debian container
 FROM debian:trixie-slim AS builder
 
@@ -14,8 +14,7 @@ ARG SRC_REPO
 RUN apt-get update && apt-get install -y --no-install-recommends build-essential ca-certificates bash git-lfs cmake
 
 WORKDIR /usr/src
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN "git clone --recurse-submodules -j8 ${SRC_REPO} nimbus-eth2 && cd nimbus-eth2 && git config advice.detachedHead false && git fetch --all --tags && if [[ ${BUILD_TARGET} =~ pr-.+ ]]; then git fetch origin pull/$(echo ${BUILD_TARGET} | cut -d '-' -f 2)/head:nim-pr; git checkout nim-pr; else git checkout ${BUILD_TARGET}; fi && make -j$(nproc) update && make -j$(nproc) nimbus_beacon_node nimbus_validator_client"
+RUN bash -o pipefail -c "git clone --recurse-submodules -j8 ${SRC_REPO} nimbus-eth2 && cd nimbus-eth2 && git config advice.detachedHead false && git fetch --all --tags && if [[ ${BUILD_TARGET} =~ pr-.+ ]]; then git fetch origin pull/$(echo ${BUILD_TARGET} | cut -d '-' -f 2)/head:nim-pr; git checkout nim-pr; else git checkout ${BUILD_TARGET}; fi && make -j$(nproc) update && make -j$(nproc) nimbus_beacon_node nimbus_validator_client"
 
 # Pull all binaries into a second stage deploy debian container
 FROM debian:trixie-slim AS consensus

--- a/nimbus/Dockerfile.sourcegnosis
+++ b/nimbus/Dockerfile.sourcegnosis
@@ -1,4 +1,4 @@
-# hadolint global ignore=DL3007,DL3008,DL3059
+# hadolint global ignore=DL3007,DL3008,DL3059,DL4006
 # Build Nimbus in a stock debian container
 FROM debian:trixie-slim AS builder
 
@@ -14,8 +14,7 @@ ARG SRC_REPO
 RUN apt-get update && apt-get install -y --no-install-recommends build-essential ca-certificates bash git-lfs cmake
 
 WORKDIR /usr/src
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN "git clone --recurse-submodules -j8 ${SRC_REPO} nimbus-eth2 && cd nimbus-eth2 && git config advice.detachedHead false && git fetch --all --tags && if [[ ${BUILD_TARGET} =~ pr-.+ ]]; then git fetch origin pull/$(echo ${BUILD_TARGET} | cut -d '-' -f 2)/head:nim-pr; git checkout nim-pr; else git checkout ${BUILD_TARGET}; fi && make -j$(nproc) update && make -j$(nproc) gnosis-build gnosis-vc-build"
+RUN bash -o pipefail -c "git clone --recurse-submodules -j8 ${SRC_REPO} nimbus-eth2 && cd nimbus-eth2 && git config advice.detachedHead false && git fetch --all --tags && if [[ ${BUILD_TARGET} =~ pr-.+ ]]; then git fetch origin pull/$(echo ${BUILD_TARGET} | cut -d '-' -f 2)/head:nim-pr; git checkout nim-pr; else git checkout ${BUILD_TARGET}; fi && make -j$(nproc) update && make -j$(nproc) gnosis-build gnosis-vc-build"
 
 # Pull all binaries into a second stage deploy debian container
 FROM debian:trixie-slim AS consensus

--- a/nimbus/Dockerfile.sourceslottime
+++ b/nimbus/Dockerfile.sourceslottime
@@ -1,4 +1,4 @@
-# hadolint global ignore=DL3007,DL3008,DL3059
+# hadolint global ignore=DL3007,DL3008,DL3059,DL4006
 # Build Nimbus in a stock debian container
 FROM debian:trixie-slim AS builder
 
@@ -15,8 +15,7 @@ ARG SECONDS_PER_SLOT=12
 RUN apt-get update && apt-get install -y --no-install-recommends build-essential ca-certificates bash git-lfs cmake
 
 WORKDIR /usr/src
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN "git clone ${SRC_REPO} nimbus-eth2 && cd nimbus-eth2 && git config advice.detachedHead false && git fetch --all --tags && git checkout ${BUILD_TARGET} && \
+RUN bash -o pipefail -c "git clone ${SRC_REPO} nimbus-eth2 && cd nimbus-eth2 && git config advice.detachedHead false && git fetch --all --tags && git checkout ${BUILD_TARGET} && \
 	make -j$(nproc) update && make -j$(nproc) NIMFLAGS=\"-d:SECONDS_PER_SLOT=${SECONDS_PER_SLOT}\" nimbus_beacon_node nimbus_validator_client"
 
 # Pull all binaries into a second stage deploy debian container

--- a/prysm/Dockerfile.source
+++ b/prysm/Dockerfile.source
@@ -1,4 +1,4 @@
-# hadolint global ignore=DL3007,DL3008,DL3016,DL3059
+# hadolint global ignore=DL3007,DL3008,DL3016,DL3059,DL4006
 # Build Prysm in a stock Go build container
 FROM golang:1.25-trixie AS builder
 
@@ -14,8 +14,7 @@ ARG SRC_REPO
 RUN apt-get update && apt-get install -y --no-install-recommends cmake libgmp-dev npm && npm install -g @bazel/bazelisk && bazel version && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /go/src
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN "git clone ${SRC_REPO} prysm && cd prysm && git config advice.detachedHead false && git fetch --all --tags && \
+RUN bash -o pipefail -c "git clone ${SRC_REPO} prysm && cd prysm && git config advice.detachedHead false && git fetch --all --tags && \
 if [[ ${BUILD_TARGET} =~ pr-.+ ]]; then git fetch origin pull/$(echo ${BUILD_TARGET} | cut -d '-' -f 2)/head:prysm-pr; git checkout prysm-pr; else git checkout ${BUILD_TARGET}; fi \
 && bazel build --config=release //cmd/beacon-chain:beacon-chain && bazel build --config=release //cmd/validator:validator && bazel build --config=release //cmd/prysmctl:prysmctl \
 && bazel build --config=release //cmd/client-stats:client-stats"

--- a/reth/Dockerfile.source
+++ b/reth/Dockerfile.source
@@ -1,4 +1,4 @@
-# hadolint global ignore=DL3007,DL3008,DL3059
+# hadolint global ignore=DL3007,DL3008,DL3059,DL4006
 # Build reth in a stock rust container
 FROM rust:trixie AS builder
 
@@ -12,8 +12,7 @@ ARG SRC_REPO
 RUN apt-get update && apt-get install -y --no-install-recommends libclang-dev
 
 WORKDIR /src
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN "git clone --recurse-submodules -j8 ${SRC_REPO} reth && cd reth \
+RUN bash -o pipefail -c "git clone --recurse-submodules -j8 ${SRC_REPO} reth && cd reth \
     && git config advice.detachedHead false && git fetch --all --tags \
     && if [[ ${BUILD_TARGET} =~ pr-.+ ]]; then git fetch origin pull/$(echo ${BUILD_TARGET} | cut -d '-' -f 2)/head:reth-pr; git checkout reth-pr; else git checkout ${BUILD_TARGET}; fi \
     && RUSTFLAGS='-C target-cpu=native' cargo build --profile maxperf --features jemalloc"

--- a/teku/Dockerfile.source
+++ b/teku/Dockerfile.source
@@ -1,4 +1,4 @@
-# hadolint global ignore=DL3007,DL3008,DL3059
+# hadolint global ignore=DL3007,DL3008,DL3059,DL4006
 # Build Teku in a stock Ubuntu container
 FROM eclipse-temurin:21-jdk-noble AS builder
 
@@ -12,8 +12,7 @@ ARG SRC_REPO
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates git
 
 WORKDIR /usr/src
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN "git clone ${SRC_REPO} teku \
+RUN bash -o pipefail -c "git clone ${SRC_REPO} teku \
   && cd teku \
   && git config advice.detachedHead false \
   && git fetch --all --tags \

--- a/vero/Dockerfile.source
+++ b/vero/Dockerfile.source
@@ -1,4 +1,4 @@
-# hadolint global ignore=DL3007,DL3008,DL3059
+# hadolint global ignore=DL3007,DL3008,DL3059,DL4006
 ARG VENV_LOCATION="/opt/venv"
 
 # Build image
@@ -21,8 +21,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y bash git && \
 ENV PATH="$VENV_LOCATION/bin:$PATH"
 # Pin uv to 0.6 until https://github.com/serenita-org/vero/pull/193 is in a release
 RUN pip install --no-cache-dir uv~=0.6.17 && uv venv ${VENV_LOCATION}
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN "git clone ${SRC_REPO} vero && cd vero && git config advice.detachedHead false && git fetch --all --tags \
+RUN bash -o pipefail -c "git clone ${SRC_REPO} vero && cd vero && git config advice.detachedHead false && git fetch --all --tags \
   && if [[ ${BUILD_TARGET} =~ pr-.+ ]]; then git fetch origin pull/$(echo ${BUILD_TARGET} | cut -d '-' -f 2)/head:vero-pr; git checkout vero-pr; else git checkout ${BUILD_TARGET}; fi \
   && uv pip sync --prefix ${VENV_LOCATION} requirements.txt"
 


### PR DESCRIPTION
**What I did**

The suggested `SHELL ["/bin/bash", "-o", "pipefail", "-c"]` doesn't work with my Dockerfiles as-is. Disabled the linter warning and added `-o pipefail` to bash
