### PR TITLE
Fix promtail regex and time parsing

### DIFF
--- a/promtail/global.yml
+++ b/promtail/global.yml
@@ -15,35 +15,29 @@ scrape_configs:
           job: containerlogs
           server: SERVER_LABEL_HOSTNAME
           __path__: /var/lib/docker/containers/*/*log
-
     pipeline_stages:
       - json:
           expressions:
             output: log
             stream: stream
-            attrs:
-
+            attrs: null
+            time: null
       - json:
           expressions:
-            tag:
+            tag: null
           source: attrs
-
       - regex:
-          expression: >
+          expression: |-
             (?P<image_name>(?:[^|]*[^|])).(?P<container_name>(?:[^|]*[^|])).(?P<image_id>(?:[^|]*[^|])).(?P<container_id>(?:[^|]*[^|]))
           source: tag
-
       - timestamp:
           format: RFC3339Nano
           source: time
-
       - labels:
-          stream:
-          container_name:
-
+          stream: null
+          container_name: null
       - labeldrop:
           - filename
-
       - output:
           source: output
 


### PR DESCRIPTION
**What I did**

Use `|-` not `>` so I don't end up with an extra space (linebreak) at the end of my regex

Pull out `time` so the timestamp stage has something to work on

Verified with `promtail --inspect`
