### PR TITLE
FIxes issue #2291 - need to use sudo to get disk usage on ancien…

### DIFF
--- a/ethd
+++ b/ethd
@@ -713,7 +713,7 @@ space() {
   __get_value_from_env "${__var}" "${__env_file}" "ANCIENT_DIR"
   if [ -n "${ANCIENT_DIR}" ]; then
     echo
-    du -sh "${ANCIENT_DIR}"
+    ${__auto_sudo} du -sh "${ANCIENT_DIR}"
   fi
 }
 


### PR DESCRIPTION
ethd space produces an error if ancient_dir flag is used for Geth

**What I did**
Changed ethd space() function line 716 to: ${__auto_sudo} du -sh "${ANCIENT_DIR}"

**Related issue**
Fixes #2291

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
