### PR TITLE
Dependabot recurses for Docker and pip

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@
 version: 2
 updates:
   - package-ecosystem: "pip"
-    directory: "/"
+    directories: "*"
     schedule:
       interval: "weekly"
     groups:
@@ -14,7 +14,7 @@ updates:
         patterns:
           - "*"
   - package-ecosystem: "docker"
-    directory: "/"
+    directories: "*"
     schedule:
       interval: "weekly"
     groups:


### PR DESCRIPTION
**What I did**

Use dependabots new-as-of-June-2024 :harold: wildcard option to recurse into subdirectories for Dockerfile and anything pip

Reference

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#directories-or-directory-- and https://github.blog/changelog/2024-06-25-simplified-dependabot-yml-configuration-with-multi-directory-key-directories-and-wildcard-glob-support/

