### PR TITLE
Besu same port IPv6

### DIFF
--- a/besu.yml
+++ b/besu.yml
@@ -28,7 +28,7 @@ services:
       - NODE_TYPE=${EL_NODE_TYPE:-pre-merge-expiry}
       - NETWORK=${NETWORK}
       - IPV6=${IPV6:-false}
-      - EL_P2P_PORT_2=${EL_P2P_PORT_2:-30304}
+      - EL_P2P_PORT=${EL_P2P_PORT:-30303}
       - COMPOSE_FILE=${COMPOSE_FILE}
     volumes:
       - besu-el-data:/var/lib/besu
@@ -52,6 +52,9 @@ services:
       - /opt/besu/bin/besu
       - --p2p-port
       - ${EL_P2P_PORT:-30303}
+      # Re-enable with Besu > 26.8.0 when CPU issue resolved
+      #- --discovery-mode
+      #- BOTH
       - --rpc-http-enabled
       - --rpc-http-host
       - 0.0.0.0

--- a/besu.yml
+++ b/besu.yml
@@ -28,7 +28,7 @@ services:
       - NODE_TYPE=${EL_NODE_TYPE:-pre-merge-expiry}
       - NETWORK=${NETWORK}
       - IPV6=${IPV6:-false}
-      - EL_P2P_PORT_2=${EL_P2P_PORT_2:-30304}
+      - EL_P2P_PORT=${EL_P2P_PORT:-30303}
       - COMPOSE_FILE=${COMPOSE_FILE}
     volumes:
       - besu-el-data:/var/lib/besu

--- a/besu/docker-entrypoint.sh
+++ b/besu/docker-entrypoint.sh
@@ -55,12 +55,22 @@ if [[ "${NETWORK}" =~ ^https?:// ]]; then
     git pull origin "${branch}"
   fi
   config_dir_path="/var/lib/besu/testnet/${config_dir}"
-  if [[ -f "${config_dir_path}/enodes.yaml" ]]; then
-    bootnodes="$(awk -F'- ' '!/^#/ && NF>1 { split($2, a, /[ \t#]/); if (a[1] != "") printf (first++ ? "," : "") a[1] } END { print "" }' "${config_dir_path}/enodes.yaml")"
-  else
+  if [[ -f "${config_dir_path}/enodes.txt" ]]; then
     bootnodes="$(paste -sd, "${config_dir_path}/enodes.txt")"
+  else
+    bootnodes="$(awk -F'- ' '!/^#/ && NF>1 { split($2, a, /[ \t#]/); if (a[1] != "") printf (first++ ? "," : "") a[1] } END { print "" }' "${config_dir_path}/enodes.yaml")"
   fi
-  __network="--genesis-file=${config_dir_path}/besu.json --bootnodes=${bootnodes}"
+  if [[ -f "${config_dir_path}/bootstrap_nodes.txt" ]]; then
+    v5_bootnodes="$(paste -sd, "${config_dir_path}/bootstrap_nodes.txt")"
+  else
+    v5_bootnodes="$(awk -F'- ' '!/^#/ && NF>1 { split($2, a, /[ \t#]/); if (a[1] != "") printf (first++ ? "," : "") a[1] } END { print "" }' "${config_dir_path}/bootstrap_nodes.yaml")"
+  fi
+  if [[ -n "${bootnodes}" && -n "${v5_bootnodes}" ]]; then
+    bootnodes+=",${v5_bootnodes}"
+  elif [[ -n "${v5_bootnodes}" ]]; then
+    bootnodes="${v5_bootnodes}"
+  fi
+  __network="--genesis-file=${config_dir_path}/besu.json --bootnodes=${bootnodes} --bonsai-limit-trie-logs-enabled=false"
 else
   __network="--network ${NETWORK}"
 fi
@@ -68,11 +78,11 @@ fi
 case "${NODE_TYPE}" in
   archive)
     echo "Besu archive node without pruning"
-    __prune="--data-storage-format=FOREST --sync-mode=FULL"
+    __prune="--data-storage-format=FOREST --sync-mode=FULL --snapsync-server-enabled"
     ;;
   full)
-    echo "Besu full node without history expiry"
-    __prune="--snapsync-synchronizer-pre-checkpoint-headers-only-enabled=false --snapsync-server-enabled"
+    echo "Besu full node without history expiry. Requires \"full\" sync and will take a long time to sync"
+    __prune="--sync-mode=FULL --bonsai-limit-trie-logs-enabled=false --snapsync-server-enabled"
     ;;
   pre-merge-expiry)
     case "${NETWORK}" in
@@ -116,9 +126,10 @@ else
 fi
 
 # DiscV5 for IPV6
-if [[ "${IPV6:-false}" = "true" ]]; then
+if [[ "${IPV6}" = "true" ]]; then
   echo "Configuring Besu for discv5 for IPv6 advertisements"
-  __ipv6="--Xv5-discovery-enabled --p2p-interface-ipv6=:: --p2p-port-ipv6=${EL_P2P_PORT_2} --p2p-ipv6-outbound-enabled"
+  # Remove discovery-mode with Besu >26.8.0 and have it as BOTH in besu.yml
+  __ipv6="--discovery-mode=V5 --p2p-interface-ipv6=:: --p2p-port-ipv6=${EL_P2P_PORT} --p2p-ipv6-outbound-enabled"
 # Address discovery on v6 is not implemented
   ipv6_pattern="^[0-9A-Fa-f]{1,4}:" # Sufficient to check the start
   set +e

--- a/besu/docker-entrypoint.sh
+++ b/besu/docker-entrypoint.sh
@@ -55,12 +55,22 @@ if [[ "${NETWORK}" =~ ^https?:// ]]; then
     git pull origin "${branch}"
   fi
   config_dir_path="/var/lib/besu/testnet/${config_dir}"
-  if [[ -f "${config_dir_path}/enodes.yaml" ]]; then
-    bootnodes="$(awk -F'- ' '!/^#/ && NF>1 { split($2, a, /[ \t#]/); if (a[1] != "") printf (first++ ? "," : "") a[1] } END { print "" }' "${config_dir_path}/enodes.yaml")"
-  else
+  if [[ -f "${config_dir_path}/enodes.txt" ]]; then
     bootnodes="$(paste -sd, "${config_dir_path}/enodes.txt")"
+  else
+    bootnodes="$(awk -F'- ' '!/^#/ && NF>1 { split($2, a, /[ \t#]/); if (a[1] != "") printf (first++ ? "," : "") a[1] } END { print "" }' "${config_dir_path}/enodes.yaml")"
   fi
-  __network="--genesis-file=${config_dir_path}/besu.json --bootnodes=${bootnodes}"
+  if [[ -f "${config_dir_path}/bootstrap_nodes.txt" ]]; then
+    v5_bootnodes="$(paste -sd, "${config_dir_path}/bootstrap_nodes.txt")"
+  else
+    v5_bootnodes="$(awk -F'- ' '!/^#/ && NF>1 { split($2, a, /[ \t#]/); if (a[1] != "") printf (first++ ? "," : "") a[1] } END { print "" }' "${config_dir_path}/bootstrap_nodes.yaml")"
+  fi
+  if [[ -n "${bootnodes}" && -n "${v5_bootnodes}" ]]; then
+    bootnodes+=",${v5_bootnodes}"
+  elif [[ -n "${v5_bootnodes}" ]]; then
+    bootnodes="${v5_bootnodes}"
+  fi
+  __network="--genesis-file=${config_dir_path}/besu.json --bootnodes=${bootnodes} --bonsai-limit-trie-logs-enabled=false"
 else
   __network="--network ${NETWORK}"
 fi
@@ -116,9 +126,9 @@ else
 fi
 
 # DiscV5 for IPV6
-if [[ "${IPV6:-false}" = "true" ]]; then
+if [[ "${IPV6}" = "true" ]]; then
   echo "Configuring Besu for discv5 for IPv6 advertisements"
-  __ipv6="--Xv5-discovery-enabled --p2p-interface-ipv6=:: --p2p-port-ipv6=${EL_P2P_PORT_2} --p2p-ipv6-outbound-enabled"
+  __ipv6="--p2p-interface-ipv6=:: --p2p-port-ipv6=${EL_P2P_PORT} --p2p-ipv6-outbound-enabled"
 # Address discovery on v6 is not implemented
   ipv6_pattern="^[0-9A-Fa-f]{1,4}:" # Sufficient to check the start
   set +e

--- a/default.env
+++ b/default.env
@@ -158,8 +158,6 @@ DOCKER_EXT_NETWORK=rocketpool_net
 # P2P ports you will forward to your staking node. Adjust here if you are
 # going to use something other than defaults.
 EL_P2P_PORT=30303
-# second EL P2P port used by Besu IPv6
-EL_P2P_PORT_2=30304
 CL_P2P_PORT=9000
 PRYSM_PORT=9000
 PRYSM_UDP_PORT=9000


### PR DESCRIPTION
**What I did**

Besu uses the same port for IPv4 and IPv6, see https://github.com/besu-eth/besu/pull/10624

Load both ENR and enode bootnodes with custom networks

`--discovery-mode BOTH` not enabled yet, it takes high CPU. Default v4 and switch to v5 with IPV6

Full node now uses full sync, because snap sync parameter for full node is deprecated
