### PR TITLE
Source builds use Go 1.27

### DIFF
--- a/erigon/Dockerfile.source
+++ b/erigon/Dockerfile.source
@@ -1,6 +1,6 @@
 # hadolint global ignore=DL3007,DL3008,DL3059,DL4006
 # Build Erigon in a stock Go build container
-FROM golang:1.26-trixie AS builder
+FROM golang:1.27-trixie AS builder
 
 # Unused, this is here to avoid build time complaints
 ARG DOCKER_TAG

--- a/flashbots/Dockerfile.source
+++ b/flashbots/Dockerfile.source
@@ -1,6 +1,6 @@
 # hadolint global ignore=DL3007,DL3008,DL3018,DL3059,DL4006
 # Build in a stock Go build container
-FROM golang:1.26-alpine AS builder
+FROM golang:1.27-alpine AS builder
 
 # Unused, this is here to avoid build time complaints
 ARG DOCKER_TAG

--- a/geth/Dockerfile.source
+++ b/geth/Dockerfile.source
@@ -1,6 +1,6 @@
 # hadolint global ignore=DL3007,DL3008,DL3018,DL3059,DL4006
 # Build Geth in a stock Go build container
-FROM golang:1.26-alpine AS builder
+FROM golang:1.27-alpine AS builder
 
 # Unused, this is here to avoid build time complaints
 ARG DOCKER_TAG

--- a/prysm/Dockerfile.source
+++ b/prysm/Dockerfile.source
@@ -1,6 +1,6 @@
 # hadolint global ignore=DL3007,DL3008,DL3016,DL3059,DL3066,DL4006
 # Build Prysm in a stock Go build container
-FROM golang:1.26-trixie AS builder
+FROM golang:1.27-trixie AS builder
 
 # Here only to avoid build-time errors
 ARG DOCKER_TAG


### PR DESCRIPTION
**What I did**

Bump golang to 1.27

In draft until Go 1.27 release probably August 25th 2026

Needs to be tested on Prysm, Geth, Erigon, flashbots, before merging
