### PR TITLE
Revert "Revert DOCKER_ROOT_MOUNTPOINT handling (#2755)"

### DIFF
--- a/ethd
+++ b/ethd
@@ -289,13 +289,11 @@ __handle_docker() {
 
     # Determine the real mountpoint backing DOCKER_ROOT, so Grafana dashboards
     # can report disk usage for that filesystem instead of always "/"
-#    if command -v findmnt >/dev/null; then
-#      DOCKER_ROOT_MOUNTPOINT=$(findmnt -T "${DOCKER_ROOT}" -o TARGET -n)
-#    else
-#      DOCKER_ROOT_MOUNTPOINT=$(df --output=target "${DOCKER_ROOT}" | tail -1)
-#    fi
-# Currently broken bcs bind mounts. Until I can find a better solution, get back to /
-    DOCKER_ROOT_MOUNTPOINT=/
+    if command -v findmnt >/dev/null; then
+      DOCKER_ROOT_MOUNTPOINT=$(findmnt -T "${DOCKER_ROOT}" -o TARGET -n)
+    else
+      DOCKER_ROOT_MOUNTPOINT=$(df --output=target "${DOCKER_ROOT}" | tail -1)
+    fi
     var=DOCKER_ROOT_MOUNTPOINT
     __get_value_from_env "${var}" "${__env_file}" "__value"
     if [[ "${DOCKER_ROOT_MOUNTPOINT}" != "${__value}" ]]; then


### PR DESCRIPTION
This reverts commit 85312981ac19964b000a290ac49093e928eabc22.

**What I did**

Restore Docker mountpoint handling. The issue I saw is specific to one of my WSL installs. I can't find root cause, but it's not likely to show up in user configurations
