### PR TITLE
ethd config creates ufw rules

### DIFF
--- a/ethd
+++ b/ethd
@@ -5229,8 +5229,43 @@ __query_grafana() {
         CORE_FILES+=":grafana-rootless.yml:grafana-shared.yml"
       else
         CORE_FILES+=":grafana.yml:grafana-shared.yml"
+        __configure_grafana_ufw
       fi
   fi
+}
+
+
+__configure_grafana_ufw() {
+  local node_exporter_port
+  local ufw_status
+
+  if [[ "${__cannot_sudo}" -eq 1 ]]; then
+    return
+  fi
+
+  if [[ -z "$(command -v ufw 2>/dev/null)" ]]; then
+    return
+  fi
+
+  if ! ufw_status=$(${__auto_sudo} ufw status 2>/dev/null); then
+    return
+  fi
+  if [[ "${ufw_status}" != *"Status: active"* ]]; then
+    return
+  fi
+
+  var=NODE_EXPORTER_PORT
+  __get_value_from_env "${var}" "${__env_file}" "__value"
+  node_exporter_port="${__value:-9199}"
+
+  if [[ "${ufw_status}" == *"${node_exporter_port}/tcp"*"ALLOW"*"172.16.0.0/12"* ]] &&
+     [[ "${ufw_status}" == *"${node_exporter_port}/tcp"*"ALLOW"*"192.168.0.0/16"* ]]; then
+    return
+  fi
+
+  echo "UFW is active and Grafana's node-exporter rules are missing. Adding them for port ${node_exporter_port}."
+  ${__auto_sudo} ufw allow proto tcp from 172.16.0.0/12 to any port "${node_exporter_port}" comment "node-exporter from Docker"
+  ${__auto_sudo} ufw allow proto tcp from 192.168.0.0/16 to any port "${node_exporter_port}" comment "node-exporter from Docker"
 }
 
 

--- a/tests/testing-ethd.md
+++ b/tests/testing-ethd.md
@@ -30,6 +30,10 @@ On Hoodi and Mainnet
 Test that MEV build factor 95 means no factor query or speedtest
 
 Test that MEV build factor "empty, 90 or 100" means factor query and speedtest
+Test Grafana with rootful Docker and active UFW: verify the node-exporter rules are added using `NODE_EXPORTER_PORT`
+Test Grafana with rootful Docker and existing node-exporter UFW rules: verify no duplicate rules are added
+Test Grafana with rootless Docker or Podman: verify no node-exporter UFW rules are added
+Test Grafana with inactive or unavailable UFW: verify configuration continues without adding rules
 
 Test all networks once, verify the expected choices are seen, configure a node on each
 Test Nimbus on Gnosis, verify that `Dockerfile.sourcegnosis` was configured for it


### PR DESCRIPTION
**What I did**

`./ethd config` will create `ufw` rules for node exporter, if they are missing. This keeps tripping users up

Parsing the output of `ufw status` is a little brittle: Still, this is better than not acting at all
