### PR TITLE
Hide pre-prague and aggressive expiry

### DIFF
--- a/default.env
+++ b/default.env
@@ -258,18 +258,13 @@ LODESTAR_HEAP=
 # Grandine has an additional "aggressive-pruned" mode, which keeps minimal data
 # For a more granular way to handle it, please use CL_EXTRAS in combination with "full"
 CL_NODE_TYPE=pruned
-# EL_NODE_TYPE can be "archive", "full", "pre-merge-expiry", "pre-prague-expiry",
-# "rolling-expiry" or "aggressive-expiry"
+# EL_NODE_TYPE can be "archive", "full", "pre-merge-expiry" or "rolling-expiry"
 # "use-cl-zkproofs" can be used with an experimental Lighthouse build, and omits the EL
 # "pre-merge-expiry" is only meaningful for mainnet and sepolia
+# "rolling-expiry" is experimental in Besu as of August 2026
 # Switching node type typically requires a resync
 # Consider using `./ethd prune-history`, which guides you as to whether to prune in-place
 # or resync, depending on client
-# "rolling-expiry" is supported with Reth, Erigon, Nethermind, Besu and Nimbus EL
-# "rolling-expiry" is experimental in Besu as of August 2026
-# "pre-prague-expiry" is supported with Geth, Reth and Nethermind
-# "aggressive-expiry" is supported with Reth, Erigon and Besu
-# "aggressive-expiry" is experimental in Besu as of Jan 27th 2026
 EL_NODE_TYPE=pre-merge-expiry
 # Whether to get a snapshot from the Reth servers, if using Reth.
 # "true" will use a (likely) correct snapshot for EL_NODE_TYPE,

--- a/ethd
+++ b/ethd
@@ -3645,23 +3645,17 @@ prune-history() {
     case "${COMPOSE_FILE}" in
       *besu.yml*)
         choices+=("rolling" "Rolling expiry (experimental)")
-        choices+=("aggressive" "Aggressive expiry (experimental)")
         ;;
       *erigon.yml*)
         choices+=("rolling" "Rolling expiry")
-        choices+=("aggressive" "Aggressive expiry")
         ;;
       *nethermind.yml*)
-        choices+=("pre-prague" "Pre-Prague expiry")
         choices+=("rolling" "Rolling expiry")
         ;;
       *reth.yml*)
-        choices+=("pre-prague" "Pre-Prague expiry")
         choices+=("rolling" "Rolling expiry")
-        choices+=("aggressive" "Aggressive expiry")
         ;;
       *geth.yml*)
-        choices+=("pre-prague" "Pre-Prague expiry")
         ;;
       *ethrex.yml*)
         ;;
@@ -6810,7 +6804,7 @@ __full_help() {
   echo "    stops the Besu execution client and prunes trie-logs."
   echo "  prune-reth [--non-interactive]"
   echo "    stops the Reth execution client and prunes its DB."
-  echo "  prune-history [--non-interactive] [--pre-merge|--pre-prague|--rolling|--aggressive]"
+  echo "  prune-history [--non-interactive] [--pre-merge|--rolling]"
   echo "    stops the execution client and configures history expiry."
   echo "  prune-lighthouse [--non-interactive]"
   echo "    stops the Lighthouse consensus client and prunes state."


### PR DESCRIPTION
**What I did**

In `default.env` and `ethd prune-history`, document only `pre-merge` and `rolling` expiry. Users can seek `pre-prague` and `aggressive` as before, by editing `.env` or calling `ethd prune-history --aggressive|--pre-prague`, but these options are no longer documented.

This simplifies setup for 99% of users, while still allowing niche configuration for those that seek it
