### PR TITLE
Geth source build with Go 1.27

### DIFF
--- a/geth/Dockerfile.source
+++ b/geth/Dockerfile.source
@@ -1,6 +1,6 @@
 # hadolint global ignore=DL3007,DL3008,DL3018,DL3059,DL4006
 # Build Geth in a stock Go build container
-FROM golang:1.26-alpine AS builder
+FROM golang:1.27-alpine AS builder
 
 # Unused, this is here to avoid build time complaints
 ARG DOCKER_TAG


### PR DESCRIPTION
**What I did**

Source build Geth with Go 1.27. Requires changes to Geth, wait for that and a release

PR: https://github.com/ethereum/go-ethereum/pull/35573
