### PR TITLE
Fix ethd version for commit-boost-pbs

### DIFF
--- a/ethd
+++ b/ethd
@@ -6702,7 +6702,7 @@ version() {
       echo
       ;;
     *commit-boost-pbs.yml*)
-      __docompose exec cb-pbs commit-boost-pbs --version
+      __docompose exec cb-pbs commit-boost --version
       echo
       ;;
   esac


### PR DESCRIPTION
**What I did**

Adjust `ethd version` to use the `commit-boost` binary
