### PR TITLE
Add CVE scan to CI

### DIFF
--- a/.github/workflows/scan-python-cve.yml
+++ b/.github/workflows/scan-python-cve.yml
@@ -1,0 +1,32 @@
+name: Scan Python dependencies for CVEs
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: traefik-utils/app
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.14'
+          cache: pip
+          cache-dependency-path: traefik-utils/app/requirements.txt
+
+      - name: Install pip-audit
+        run: python -m pip install pip-audit
+
+      - name: Scan requirements.txt for known vulnerabilities
+        run: pip-audit -r requirements.txt


### PR DESCRIPTION
**What I did**

Add a CI step that runs on every PR and scans the `traefik-utils/app` dependencies for CVEs

Created by DeepSeek V4 Flash
