### PR TITLE
Fix client matrix references in vc-env conditions

### DIFF
--- a/.github/workflows/build-clients.yml
+++ b/.github/workflows/build-clients.yml
@@ -194,7 +194,7 @@ jobs:
           test_el: ${{ matrix.client.test_el }}
           test_vc: ${{ matrix.client.test_vc }}
       - name: Set env variables
-        if: ${{ matrix.combo.vc-env && matrix.combo.vc-env != '' }}
+        if: ${{ matrix.client.vc-env && matrix.client.vc-env != '' }}
         run: |
           source ./.github/helper.sh
           while IFS= read -r varpair; do
@@ -204,7 +204,7 @@ jobs:
             set_value_in_env
           done <<< "${{ matrix.client.vc-env }}"
       - name: Test the stack
-        if: ${{ matrix.combo.vc-env && matrix.combo.vc-env != '' }}
+        if: ${{ matrix.client.vc-env && matrix.client.vc-env != '' }}
         uses: ./.github/actions/test_client_stack
         with:
           test_cl: ${{ matrix.client.test_cl }}


### PR DESCRIPTION
**What I did**

Fixed the `Set env variables` and `Test the stack` conditions in the client build workflow. The matrix defines each entry under `matrix.client`, and the run block already reads `${{ matrix.client.vc-env }}`, but both conditions incorrectly checked `matrix.combo.vc-env`.

Using `matrix.client.vc-env` consistently allows the steps to run for client entries that provide validator-client environment variables.

Validation: `actionlint .github/workflows/build-clients.yml`


**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

None; this is a self-contained workflow expression fix.


**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

<img width="1440" height="1920" alt="3d7f88f017b44d619402fb4b9e7be9dd" src="https://github.com/user-attachments/assets/0f083497-dfcd-4696-b342-066cc379a06c" />

