### PR TITLE
Fix Prysm keymanager parameters

### DIFF
--- a/default.env
+++ b/default.env
@@ -82,10 +82,9 @@ CNAME_LIST=
 # Whether to default to proxied or not in CloudFlare.
 CF_PROXY=true
 # Host names used in their respective *-traefik.yml files, to be reachable via traefik
-# Grafana, Siren and Prysm Web are exposed via traefik by default, if traefik is in use
+# Grafana and Siren are exposed via traefik by default, if traefik is in use
 GRAFANA_HOST=grafana
 SIREN_HOST=siren
-PRYSM_HOST=prysm
 # ee-traefik.yml. This is EXTREMELY niche, do not expose engine API just because
 EE_HOST=engine
 # el-traefik.yml to expose the execution RPC and WS APIs

--- a/prysm-vc-only.yml
+++ b/prysm-vc-only.yml
@@ -75,17 +75,12 @@ services:
       - 0.0.0.0
       - --http-port
       - ${KEY_API_PORT:-7500}
-      - --http-cors-domain=*
+      - --rpc
       - --suggested-fee-recipient
       - ${FEE_RECIPIENT}
       - --wallet-password-file
       - /var/lib/prysm/password.txt
     labels:
-      - traefik.enable=true
-      - traefik.http.routers.prysm.entrypoints=web,websecure
-      - traefik.http.routers.prysm.rule=Host(`${PRYSM_HOST}.${DOMAIN}`)
-      - traefik.http.routers.prysm.tls.certresolver=letsencrypt
-      - traefik.http.services.prysm.loadbalancer.server.port=${KEY_API_PORT:-7500}
       - metrics.scrape=true
       - metrics.path=/metrics
       - metrics.port=8009

--- a/prysm.yml
+++ b/prysm.yml
@@ -155,17 +155,12 @@ services:
       - 0.0.0.0
       - --http-port
       - ${KEY_API_PORT:-7500}
-      - --http-cors-domain=*
+      - --rpc
       - --suggested-fee-recipient
       - ${FEE_RECIPIENT}
       - --wallet-password-file
       - /var/lib/prysm/password.txt
     labels:
-      - traefik.enable=true
-      - traefik.http.routers.prysm.entrypoints=web,websecure
-      - traefik.http.routers.prysm.rule=Host(`${PRYSM_HOST}.${DOMAIN}`)
-      - traefik.http.routers.prysm.tls.certresolver=letsencrypt
-      - traefik.http.services.prysm.loadbalancer.server.port=${KEY_API_PORT:-7500}
       - metrics.scrape=true
       - metrics.path=/metrics
       - metrics.port=8009

--- a/prysm/docker-entrypoint-vc.sh
+++ b/prysm/docker-entrypoint-vc.sh
@@ -52,7 +52,7 @@ if [[ "${WEB3SIGNER}" = "true" ]]; then
     touch /var/lib/prysm/w3s-keys.txt
   fi
 else
-  __w3s_url="--web --wallet-password-file /var/lib/prysm/password.txt"
+  __w3s_url="--wallet-password-file /var/lib/prysm/password.txt"
 fi
 
 # Distributed attestation aggregation


### PR DESCRIPTION
**What I did**

Prysm web UI removal was incomplete, and keymanager still relied on it. This caused web3signer setups to fail. Switch to `--rpc` parameter on the VC to make sure keymanager is up.

Tested with and without web3signer

**Related issue**
closes #2810 
