### PR TITLE
Remove unmaintained pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,14 +22,10 @@ repos:
       - id: requirements-txt-fixer
       - id: check-toml
 
-  - repo: https://github.com/jumanjihouse/pre-commit-hooks
-    rev: 38980559e3a605691d6579f96222c30778e5a69e
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: 745eface02aef23e168a8afb6b5737818efbea95
     hooks:
       - id: shellcheck
-      - id: script-must-have-extension
-      - id: git-dirty
-      - id: git-check
-      - id: forbid-binary
 
   # Python formatting & linting
   - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/ethd
+++ b/ethd
@@ -626,6 +626,7 @@ __upgrade_compose() {
     ${__auto_sudo} install -m 0755 -d /etc/apt/keyrings
     ${__auto_sudo} curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
     ${__auto_sudo} chmod a+r /etc/apt/keyrings/docker.asc
+    # shellcheck source=/dev/null
     ${__auto_sudo} tee /etc/apt/sources.list.d/docker.sources <<EOF
 Types: deb
 URIs: https://download.docker.com/linux/debian
@@ -1104,6 +1105,7 @@ __install_docker() {
     ${__auto_sudo} install -m 0755 -d /etc/apt/keyrings
     ${__auto_sudo} curl -fsSL https://download.docker.com/linux/${repo}/gpg -o /etc/apt/keyrings/docker.asc
     ${__auto_sudo} chmod a+r /etc/apt/keyrings/docker.asc
+    # shellcheck source=/dev/null
     ${__auto_sudo} tee /etc/apt/sources.list.d/docker.sources <<EOF
 Types: deb
 URIs: https://download.docker.com/linux/${repo}

--- a/tests/test-multiuser.sh
+++ b/tests/test-multiuser.sh
@@ -326,6 +326,7 @@ __check_os() {
     echo "Aborting"
     exit 0
   fi
+  # shellcheck source=/dev/null
   . /etc/os-release
   if [[ ! "$ID" =~ (debian|ubuntu) ]]; then
     echo "ERROR: This script is designed to be run on Debian or Ubuntu, and you don't appear to be running either."


### PR DESCRIPTION
**What I did**

`https://github.com/jumanjihouse/pre-commit-hooks` hasn't been maintained for 4 years. Remove. 

shellcheck becomes `https://github.com/shellcheck-py/shellcheck-py`
